### PR TITLE
fix muladd by constant

### DIFF
--- a/ocelot/src/ir/PTXInstruction.cpp
+++ b/ocelot/src/ir/PTXInstruction.cpp
@@ -1037,7 +1037,7 @@ std::string ir::PTXInstruction::valid() const {
 					return "requires a rounding modifier";
 				}
 			}
-			if( a.type != b.type ) {
+			if( a.type != b.type && a.type != PTXOperand::b32) {
 				return "type of operand A " + PTXOperand::toString( a.type ) 
 					+ " does not equal type of operand B " 
 					+ PTXOperand::toString( b.type );


### PR DESCRIPTION
Fixes a crash when running tinygrad emulation tests.
```
test/test_ops.py::TestOps::test_cmp_ge terminate called after throwing an instance of 'parser::PTXParser::Exception'
  what():  
Failed to parse file '':
32      cvta.to.global.u64      %rd6, %rd2;
33      mov.u32         %r1, %ntid.y;
34      mov.u32         %r2, %ctaid.y;
35      mov.u32         %r3, %tid.y;
36      mad.lo.s32      %r4, %r1, %r2, %r3;
37      mov.u32         %r5, %ntid.x;
38      mov.u32         %r6, %ctaid.x;
39      mov.u32         %r7, %tid.x;
40      mad.lo.s32      %r8, %r5, %r6, %r7;
41      mad.lo.s32      %r9, %r4, 5, %r8;
42      mul.wide.s32    %rd7, %r9, 4;
43      add.s64         %rd8, %rd6, %rd7;
44      ld.global.f32   %f1, [%rd8];
45      mul.wide.s32    %rd9, %r8, 4;
46      add.s64         %rd10, %rd5, %rd9;
47      ld.global.f32   %f2, [%rd10];
48      max.f32         %f3, %f1, %f2;
49      setp.eq.f32     %p1, %f3, %f1;
50      selp.f32        %f4, 0f3F800000, 0f00000000, %p1;
51      add.s64         %rd11, %rd4, %rd7;
52 
 (41, 5): Parsed invalid instruction mad.lo.s32 %r9, %r4, 5, %r8 : type of operand A b32 does not equal type of operand B s32
Fatal Python error: Aborted
```