### PR TITLE
Fix bfe operation sign determination

### DIFF
--- a/ocelot/src/executive/CooperativeThreadArray.cpp
+++ b/ocelot/src/executive/CooperativeThreadArray.cpp
@@ -2377,15 +2377,16 @@ void executive::CooperativeThreadArray::eval_Bfe(CTAContext &context,
 		bool isSigned = (instr.type == ir::PTXOperand::s32
 			|| instr.type == ir::PTXOperand::s64);
 
-		ir::PTXU32 msb    = (size32bit ? 31 : 63);
 		ir::PTXU32 pos    = operandAsU32(tid, instr.b);
 		ir::PTXU32 len    = operandAsU32(tid, instr.c);
 		ir::PTXU64 a      = operandAsU64(tid, instr.a);
 		ir::PTXU64 mask   = ((1 << len) - 1);
+		ir::PTXU32 msb	  = min((pos+len-1), size32bit ? 31 : 63);
+		ir::PTXU32 sign   = ((a>>(msb))&1);
 		ir::PTXU64 result = 0;
 
 		if (isSigned) {
-			result = (msb ? -1 : 0) & (~mask);
+			result = (sign ? -1 : 0) & (~mask);
 		}
 		result |= ((a >> pos) & mask);
 		if (size32bit) {


### PR DESCRIPTION
from https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#integer-arithmetic-instructions-bfe :
The sign bit of the extracted field is defined as:

.u32, .u64:
zero

.s32, .s64:
msb of input a if the extracted field extends beyond the msb of a msb of extracted field, otherwise