### PR TITLE
mad must accept any integers of the same size

### DIFF
--- a/ocelot/src/ir/PTXInstruction.cpp
+++ b/ocelot/src/ir/PTXInstruction.cpp
@@ -1037,10 +1037,11 @@ std::string ir::PTXInstruction::valid() const {
 					return "requires a rounding modifier";
 				}
 			}
-			if( a.type != b.type && a.type != PTXOperand::b32) {
+			if( !PTXOperand::valid(a.type, b.type) ) {
 				return "type of operand A " + PTXOperand::toString( a.type ) 
-					+ " does not equal type of operand B " 
-					+ PTXOperand::toString( b.type );
+					+ " is not interoperable with type of operand B "
+					+ PTXOperand::toString( b.type )
+					+ ", conversion is required";
 			}
 			if( !( c.bytes() == d.bytes() ) ) {
 				std::stringstream stream;


### PR DESCRIPTION
This patch fixes #18 by relaxing the MAD operand requirements according to the PTX spec: MAD must accept any types of arguments that do not require explicit type conversion described in [Table 13](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#scalar-conversions-convert-instruction-precision-and-format).
