### PR TITLE
bump res_embed

### DIFF
--- a/ocelot/CMakeLists.txt
+++ b/ocelot/CMakeLists.txt
@@ -215,6 +215,7 @@ add_library(llvm INTERFACE)
 add_dependencies(llvm llvm-project)
 endif()
 
+set(BUILD_SHARED_LIBS OFF)  # ThirdParty/res_embed option
 add_subdirectory(ThirdParty/hydrazine)
 add_subdirectory(ThirdParty/res_embed EXCLUDE_FROM_ALL)
 


### PR DESCRIPTION
Bumping res_embed to version that supports apple silicon (https://github.com/dmikushin/res_embed/pull/9).

Part of the patches I am upstreaming from https://github.com/tinygrad/tinygrad/pull/8209 to build GPUOcelot on OSX.

